### PR TITLE
Fix keywords meta tag

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const isHomePage = new URL(Astro.request.url).pathname === "/";
 
     <meta name="title" content={title} />
     <meta name="description" content={description} />
-    <meta name="kewords" content={keywords} />
+    <meta name="keywords" content={keywords} />
 
     <!-- Open Graph -->
     <!-- Facebook Meta Tags -->


### PR DESCRIPTION
## Summary
- fix `keywords` meta tag name in the main layout

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_68953e37164083329f98946438cc657f